### PR TITLE
Add .tar.gz to fix failure w/lxd 2.18

### DIFF
--- a/lxdbackup
+++ b/lxdbackup
@@ -137,7 +137,7 @@ main () {
     fi
 
     # Export lxc image to image.tar.gz file.
-    if $LXC image export $LXCCONTAINER-BACKUP-$BACKUPDATE-IMAGE $LXCCONTAINER-BACKUP-$BACKUPDATE-IMAGE; then
+    if $LXC image export $LXCCONTAINER-BACKUP-$BACKUPDATE-IMAGE $LXCCONTAINER-BACKUP-$BACKUPDATE-IMAGE.tar.gz; then
         lecho "Image: Succesfully exported an image of $LXCCONTAINER-BACKUP-$BACKUPDATE-IMAGE to $WORKDIR/$LXCCONTAINER-BACKUP-$BACKUPDATE-IMAGE.tar.gz"
     else
         lecho "Image: Could not publish image from $LXCCONTAINER-BACKUP-$BACKUPDATE-IMAGE to $WORKDIR/$LXCCONTAINER-BACKUP-$BACKUPDATE-IMAGE.tar.gz"


### PR DESCRIPTION
Script would persistently fail after the export phase with repeated "error reading source directory: directory not found" error. Script appeared to be looking for a container backup file in `/tmp/lxdbackup` ending in `.tar.gz`, but the export function in lxd/lxc 2.18 produces a file with no extension unless one is specified. Appending `.tar.gz` onto the image name on line 140 fixes the problem and backups complete & upload themselves successfully.